### PR TITLE
Minor spelling fixes for arquillian

### DIFF
--- a/whatsnew/arquillian/arquillian-news-4.1.0.Beta1.html
+++ b/whatsnew/arquillian/arquillian-news-4.1.0.Beta1.html
@@ -157,7 +157,7 @@ The Remove Arquillian Support removes the Arquillian nature, but doesn't change 
               The Run As Arquillian launch configuration includes the following features:
             </p>
 			<ul>
-    			<li>is actived only if there is the org.jboss.arquillian.junit.Arquillian class</li>
+    			<li>is activated only if there is the org.jboss.arquillian.junit.Arquillian class</li>
     			<li>runs only Arquillian JUnit tests</li>
     			<li>checks if there is exactly one implementation of the org.jboss.arquillian.container.spi.client.container.DeployableContainer interface</li>
     			<li>includes the Arquillian tab that enables the user to check/change the Arquillian configuration properties, select maven profiles, review/start/stop WTP servers. The Arquillian configuration properties are added using declarations from the arquillian.xml, arquillian.properties and the default values when instantiating the corresponding container configuration.</li>
@@ -182,7 +182,7 @@ The Remove Arquillian Support removes the Arquillian nature, but doesn't change 
           <a name="arquillianvalidator" id="arquillianvalidator"></a><b>Arquillian Validator</b></td>
           <td valign="top">
             <p>
-              The arquillian validator finds the following issues:
+              The Arquillian Validator finds the following issues:
             </p>
 			<ul>
     			<li>classes that are used in a test, but aren't included in the deployment</li>


### PR DESCRIPTION
actived->activated
- I don't think the former is a word

arquillian validator->Arquillian Validator
- This kind of thing seems capitalised in most places:
  Arquillian Eclipse
  Arquillian Profiles
  Generate Arquillian Deployment Method
  etc
