### PR TITLE
JBIDE-13815 Fix a remaining ws version mismatch in N&N

### DIFF
--- a/whatsnew/ws/ws-news-1.2.0.M2.html
+++ b/whatsnew/ws/ws-news-1.2.0.M2.html
@@ -21,7 +21,7 @@
 
 </script></head>
 <body>
-<h1>WS tools 3.2.0 M2 What's New</h1>
+<h1>WS tools 1.2.0 M2 What's New</h1>
 
 <p align="right"><a href="../index.html">&lt; Main Index</a>  <a href="../deltacloud/deltacloud-news-0.0.1.M2.html">Deltacloud Development Tools &gt;</a></p>
 


### PR DESCRIPTION
The version displayed on the page (in <hX></hX>) didn't match the version in
<title></title> and the file name.
