### PR TITLE
TOOLSDOC-309: Removing unnecessary JBT guides from jenkins build as a result of new User Guide

### DIFF
--- a/jboss-tools-docs/all-guides.xml
+++ b/jboss-tools-docs/all-guides.xml
@@ -20,9 +20,12 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
+
 			<fileSet>
-				<directory>../guides/GettingStartedGuide/target/docbook/publish/en-US</directory>
-				<outputDirectory>/GettingStartedGuide</outputDirectory>
+				<!-- <directory>../../birt/docs/target/docbook/publish/en-US</directory> -->
+				<!-- Birt doc has moved to https://github.com/jbosstools/jbosstools-birt/-->				
+				<directory>../../jbosstools-birt/docs/target/docbook/publish/en-US</directory>				
+				<outputDirectory>/jboss_birt_plugin_ref_guide</outputDirectory>
 				<filtered>false</filtered>
 				<lineEnding>keep</lineEnding>
 				<includes>
@@ -33,19 +36,7 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
-			<fileSet>
-				<directory>../guides/Beginners_Guide/target/docbook/publish/en-US</directory>
-				<outputDirectory>/beginners_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
+		
 			<fileSet>
 				<!-- <directory>../../cdi/docs/reference/target/docbook/publish/en-US</directory> -->
 				<!-- CDI doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
@@ -61,9 +52,12 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
-			<fileSet>
-				<directory>../guides/Legacy-jsf/target/docbook/publish/en-US</directory>
-				<outputDirectory>/Legacy-jsf</outputDirectory>
+			
+            <fileSet>
+				<!-- <directory>../../esb/docs/esb_ref_guide/target/docbook/publish/en-US</directory> -->
+				<!-- ESB doc has moved to https://github.com/jbosstools/jbosstools-esb/-->
+				<directory>../../jbosstools-esb/docs/esb_ref_guide/target/docbook/publish/en-US</directory>
+				<outputDirectory>/esb_ref_guide</outputDirectory>
 				<filtered>false</filtered>
 				<lineEnding>keep</lineEnding>
 				<includes>
@@ -74,36 +68,7 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
-			<fileSet>
-				<!-- <directory>../../as/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- Server Manager doc has moved to https://github.com/jbosstools/jbosstools-server/-->
-				<directory>../../jbosstools-server/as/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/as</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-			<fileSet>
-				<!-- <directory>../../openshift/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- OpenShift doc has moved to https://github.com/jbosstools/jbosstools-openshift/-->
-				<directory>../../jbosstools-openshift/docs/reference/target/docbook/publish/en-US</directory>				
-				<outputDirectory>/openshift_tools_reference_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet> 
+
 			<fileSet>
 				<!-- <directory>../../hibernatetools/docs/reference/target/docbook/publish/en-US</directory> -->
 				<!-- Hibernate doc has moved to https://github.com/jbosstools/jbosstools-hibernate/-->
@@ -119,11 +84,28 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
+			
 			<fileSet>
-				<!-- <directory>../../jbpm/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- jBPM doc has moved to https://github.com/jbosstools/jbosstools-jbpm/-->
-				<directory>../../jbosstools-jbpm/docs/reference/target/docbook/publish/en-US</directory>				
-				<outputDirectory>/jboss_jbpm_ref_guide</outputDirectory>
+				<!-- <directory>../../portlet/docs/reference/target/docbook/publish/en-US</directory> -->
+				<!-- Portal doc has moved to https://github.com/jbosstools/jbosstools-portlet/-->
+				<directory>../../jbosstools-portlet/docs/reference/target/docbook/publish/en-US</directory>
+				<outputDirectory>/jboss_portal_tools_ref_guide</outputDirectory>
+				<filtered>false</filtered>
+				<lineEnding>keep</lineEnding>
+				<includes>
+					<include>**/*.*</include>
+				</includes>
+				<useStrictFiltering>false</useStrictFiltering>
+				<useDefaultExcludes>true</useDefaultExcludes>
+				<fileMode>0644</fileMode>
+				<directoryMode>0755</directoryMode>
+			</fileSet>	
+	
+			<fileSet>
+				<!-- <directory>../../jmx/docs/reference/target/docbook/publish/en-US</directory> -->
+				<!-- JMX doc has moved to https://github.com/jbosstools/jbosstools-server/-->
+				<directory>../../jbosstools-server/jmx/docs/reference/target/docbook/publish/en-US</directory>
+				<outputDirectory>/jmx_ref_guide</outputDirectory>
 				<filtered>false</filtered>
 				<lineEnding>keep</lineEnding>
 				<includes>
@@ -134,66 +116,7 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
-			<fileSet>
-				<!-- <directory>../../jbpm/docs/converter_ref/target/docbook/publish/en-US</directory> -->
-				<!-- BPMN doc has moved to https://github.com/jbosstools/jbosstools-jbpm/-->
-				<directory>../../jbosstools-jbpm/docs/converter_ref/target/docbook/publish/en-US</directory>
-				<outputDirectory>/jboss_bpmn_convert_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-			<fileSet>
-				<!-- <directory>../../jsf/docs/userguide/target/docbook/publish/en-US</directory> -->
-				<!-- Visual Web doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
-				<directory>../../jbosstools-javaee/jsf/docs/userguide/target/docbook/publish/en-US</directory>
-				<outputDirectory>/jsf</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-			<fileSet>
-				<!-- <directory>../../seam/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- Seam doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
-				<directory>../../jbosstools-javaee/seam/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/seam</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-			<fileSet>
-				<!-- <directory>../../seam/docs/tutorial/target/docbook/publish/en-US</directory> -->
-				<!-- Seam tut has moved to https://github.com/jbosstools/jbosstools-/-->
-				<directory>../../jbosstools-javaee/seam/docs/tutorial/target/docbook/publish/en-US</directory>
-				<outputDirectory>/seam_tutorial</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
+
 			<fileSet>
 				<!-- <directory>../../jsf/docs/jsf_tools_ref_guide/target/docbook/publish/en-US</directory> -->
 				<!-- JSF doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
@@ -226,11 +149,59 @@
 				<directoryMode>0755</directoryMode>
 			</fileSet>
 
-            <fileSet>
-				<!-- <directory>../../esb/docs/esb_ref_guide/target/docbook/publish/en-US</directory> -->
-				<!-- ESB doc has moved to https://github.com/jbosstools/jbosstools-esb/-->
-				<directory>../../jbosstools-esb/docs/esb_ref_guide/target/docbook/publish/en-US</directory>				
-				<outputDirectory>/esb_ref_guide</outputDirectory>
+			<fileSet>
+				<!-- <directory>../../maven/docs/reference/target/docbook/publish/en-US</directory> -->
+				<!-- Maven doc has moved to https://github.com/jbosstools/jbosstools-central/-->
+				<directory>../../jbosstools-central/maven/docs/reference/target/docbook/publish/en-US</directory>
+				<outputDirectory>/maven_reference</outputDirectory>
+				<filtered>false</filtered>
+				<lineEnding>keep</lineEnding>
+				<includes>
+					<include>**/*.*</include>
+				</includes>
+				<useStrictFiltering>false</useStrictFiltering>
+				<useDefaultExcludes>true</useDefaultExcludes>
+				<fileMode>0644</fileMode>
+				<directoryMode>0755</directoryMode>
+			</fileSet>
+
+			<fileSet>
+				<!-- <directory>../../seam/docs/reference/target/docbook/publish/en-US</directory> -->
+				<!-- Seam doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
+				<directory>../../jbosstools-javaee/seam/docs/reference/target/docbook/publish/en-US</directory>
+				<outputDirectory>/seam</outputDirectory>
+				<filtered>false</filtered>
+				<lineEnding>keep</lineEnding>
+				<includes>
+					<include>**/*.*</include>
+				</includes>
+				<useStrictFiltering>false</useStrictFiltering>
+				<useDefaultExcludes>true</useDefaultExcludes>
+				<fileMode>0644</fileMode>
+				<directoryMode>0755</directoryMode>
+			</fileSet>
+			
+			<fileSet>
+				<!-- <directory>../../seam/docs/tutorial/target/docbook/publish/en-US</directory> -->
+				<!-- Seam tut has moved to https://github.com/jbosstools/jbosstools-/-->
+				<directory>../../jbosstools-javaee/seam/docs/tutorial/target/docbook/publish/en-US</directory>
+				<outputDirectory>/seam_tutorial</outputDirectory>
+				<filtered>false</filtered>
+				<lineEnding>keep</lineEnding>
+				<includes>
+					<include>**/*.*</include>
+				</includes>
+				<useStrictFiltering>false</useStrictFiltering>
+				<useDefaultExcludes>true</useDefaultExcludes>
+				<fileMode>0644</fileMode>
+				<directoryMode>0755</directoryMode>
+			</fileSet>
+
+			<fileSet>
+				<!-- <directory>../../jsf/docs/userguide/target/docbook/publish/en-US</directory> -->
+				<!-- Visual Web doc has moved to https://github.com/jbosstools/jbosstools-javaee/-->
+				<directory>../../jbosstools-javaee/jsf/docs/userguide/target/docbook/publish/en-US</directory>
+				<outputDirectory>/jsf</outputDirectory>
 				<filtered>false</filtered>
 				<lineEnding>keep</lineEnding>
 				<includes>
@@ -275,116 +246,6 @@
 			</fileSet>
 
 			<fileSet>
-				<!-- <directory>../../portlet/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- Portal doc has moved to https://github.com/jbosstools/jbosstools-portlet/-->
-				<directory>../../jbosstools-portlet/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/jboss_portal_tools_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-			<fileSet>
-				<!-- <directory>../../birt/docs/target/docbook/publish/en-US</directory> -->
-				<!-- Birt doc has moved to https://github.com/jbosstools/jbosstools-birt/-->				
-				<directory>../../jbosstools-birt/docs/target/docbook/publish/en-US</directory>				
-				<outputDirectory>/jboss_birt_plugin_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-			<!-- These docs are now hosted at http://docs.jboss.org/drools/release/
-			<fileSet>
-				<directory>../../drools/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/drools_tools_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-			<fileSet>
-				<directory>../../drools/docs/guvnor_ref/target/docbook/publish/en-US</directory>
-				<outputDirectory>/guvnor_tools_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet> -->
-
-			<fileSet>
-				<!-- <directory>../../maven/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- Maven doc has moved to https://github.com/jbosstools/jbosstools-central/-->
-				<directory>../../jbosstools-central/maven/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/maven_reference</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-			<fileSet>
-				<!-- <directory>../../forge/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- Forge doc has moved to https://github.com/jbosstools/jbosstools-forge/-->
-				<directory>../../jbosstools-forge/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/forge_reference</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-			<fileSet>
-				<!-- <directory>../../jmx/docs/reference/target/docbook/publish/en-US</directory> -->
-				<!-- JMX doc has moved to https://github.com/jbosstools/jbosstools-server/-->
-				<directory>../../jbosstools-server/jmx/docs/reference/target/docbook/publish/en-US</directory>
-				<outputDirectory>/jmx_ref_guide</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet>
-
-
-			<fileSet>
 				<!-- <directory>../../bpel/docs/reference/target/docbook/publish/en-US</directory> -->
 				<!-- BPEL doc has moved to https://github.com/jbosstools/jbosstools-bpel/-->
 				<directory>../../jbosstools-bpel/docs/reference/target/docbook/publish/en-US</directory>
@@ -399,21 +260,7 @@
 				<fileMode>0644</fileMode>
 				<directoryMode>0755</directoryMode>
 			</fileSet>
-			<fileSet>
-				<!-- <directory>../../modeshape/docs/ModeShape_Tools_Reference_Guide/target/docbook/publish/en-US</directory> -->
-				<!-- ModeShape doc has moved to https://github.com/ModeShape/modeshape-tools/-->
-				<directory>../../../ModeShape/modeshape-tools/docs/ModeShape_Tools_Reference_Guide/target/docbook/publish/en-US</directory>
-				<outputDirectory>/modeshape</outputDirectory>
-				<filtered>false</filtered>
-				<lineEnding>keep</lineEnding>
-				<includes>
-					<include>**/*.*</include>
-				</includes>
-				<useStrictFiltering>false</useStrictFiltering>
-				<useDefaultExcludes>true</useDefaultExcludes>
-				<fileMode>0644</fileMode>
-				<directoryMode>0755</directoryMode>
-			</fileSet> 
+
 	</fileSets>
 
 </assembly>

--- a/jboss-tools-docs/index/en-US/master.xml
+++ b/jboss-tools-docs/index/en-US/master.xml
@@ -20,22 +20,6 @@
                 >(pdf)</ulink>
             </primaryie>
         </indexentry>
-	<indexentry>
-            <primaryie>Getting Started with JBoss Developer Studio Guide <ulink
-                    url="en/GettingStartedGuide/html/index.html">(html)</ulink>
-                <ulink url="en/GettingStartedGuide/html_single/index.html">(html single)</ulink>
-                <ulink url="en/GettingStartedGuide/pdf/Getting_Started_Guide.pdf"
-                >(pdf)</ulink>
-            </primaryie>
-        </indexentry>
-        <indexentry>
-            <primaryie>Beginners Guide <ulink
-                    url="en/beginners_guide/html/index.html">(html)</ulink>
-                <ulink url="en/beginners_guide/html_single/index.html">(html single)</ulink>
-                <ulink url="en/beginners_guide/pdf/Beginners_Guide.pdf"
-                >(pdf)</ulink>
-            </primaryie>
-        </indexentry>
 		
 		<indexentry>
 			<primaryie>Birt Plugin Integration Reference Guide <ulink
@@ -43,10 +27,10 @@
 				<ulink url="en/jboss_birt_plugin_ref_guide/html_single/index.html">(html single)</ulink>
 				<ulink url="en/jboss_birt_plugin_ref_guide/pdf/Birt_Reference_Guide.pdf"
 					>(pdf)</ulink>
-				</primaryie>
-			</indexentry>
+			</primaryie>
+		</indexentry>
 		
-	<indexentry>
+		<indexentry>
             <primaryie>CDI Tools Reference Guide <ulink
                     url="en/cdi_tools_reference_guide/html/index.html">(html)</ulink>
                 <ulink url="en/cdi_tools_reference_guide/html_single/index.html">(html single)</ulink>
@@ -61,44 +45,27 @@
 				<ulink url="en/esb_ref_guide/html_single/index.html">(html single)</ulink>
 				<ulink url="en/esb_ref_guide/pdf/ESB_Reference_Guide.pdf"
 					>(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>Forge Reference Guide <ulink
+			</primaryie>
+		</indexentry>
 
-					url="en/forge_reference/html/index.html">(html)</ulink>
-					<ulink url="en/forge_reference/html_single/index.html">(html single)</ulink>
-					<ulink url="en/forge_reference/pdf/Forge_Reference_Guide.pdf">(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-
-			<indexentry>
-				<primaryie>Hibernate Tools Reference Guide 
-					<ulink url="en/hibernatetools/html/index.html">(html)</ulink>
-					<ulink url="en/hibernatetools/html_single/index.html">(html single)</ulink>
-					<ulink url="en/hibernatetools/pdf/Hibernatetools_Reference_Guide.pdf"
-						>(pdf)</ulink>
-					</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>JBoss Portal Tools Reference Guide <ulink
-					url="en/jboss_portal_tools_ref_guide/html/index.html">(html)</ulink>
-					<ulink url="en/jboss_portal_tools_ref_guide/html_single/index.html">(html single)</ulink>
-					<ulink url="en/jboss_portal_tools_ref_guide/pdf/JBoss_Portal_Tools_Reference_Guide.pdf"
-						>(pdf)</ulink>
-					</primaryie>
-				</indexentry>
-
-        <indexentry>
-            <primaryie>JBoss Server Manager Reference Guide <ulink url="en/as/html/index.html"
-                    >(html)</ulink>
-                <ulink url="en/as/html_single/index.html">(html single)</ulink>
-                <ulink url="en/as/pdf/AS_Reference_Guide.pdf">(pdf)</ulink>
-            </primaryie>
-        </indexentry>
+		<indexentry>
+			<primaryie>Hibernate Tools Reference Guide 
+				<ulink url="en/hibernatetools/html/index.html">(html)</ulink>
+				<ulink url="en/hibernatetools/html_single/index.html">(html single)</ulink>
+				<ulink url="en/hibernatetools/pdf/Hibernatetools_Reference_Guide.pdf"
+					>(pdf)</ulink>
+			</primaryie>
+		</indexentry>
 		
+		<indexentry>
+			<primaryie>JBoss Portal Tools Reference Guide <ulink
+				url="en/jboss_portal_tools_ref_guide/html/index.html">(html)</ulink>
+				<ulink url="en/jboss_portal_tools_ref_guide/html_single/index.html">(html single)</ulink>
+				<ulink url="en/jboss_portal_tools_ref_guide/pdf/JBoss_Portal_Tools_Reference_Guide.pdf"
+					>(pdf)</ulink>
+			</primaryie>
+		</indexentry>
+	
 		<indexentry>
 			<primaryie>JMX Reference Guide <ulink
 				url="en/jmx_ref_guide/html/index.html">(html)</ulink>
@@ -113,36 +80,27 @@
 				<ulink url="en/jsf_tools_ref_guide/html_single/index.html">(html single)</ulink>
 				<ulink url="en/jsf_tools_ref_guide/pdf/JSF_Tools_Reference_Guide.pdf"
 					>(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>JSF Tools Tutorial <ulink url="en/jsf_tools_tutorial/html/index.html"
-					>(html)</ulink>
-					<ulink url="en/jsf_tools_tutorial/html_single/index.html">(html single)</ulink>
-					<ulink url="en/jsf_tools_tutorial/pdf/JSF_Tools_Tutorial.pdf">(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>Maven Reference Guide <ulink
-					url="en/maven_reference/html/index.html">(html)</ulink>
-					<ulink url="en/maven_reference/html_single/index.html">(html single)</ulink>
-					<ulink url="en/maven_reference/pdf/Maven_Tools_Reference_Guide.pdf">(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>OpenShift Tools Reference Guide <ulink
-					url="en/openshift_tools_reference_guide/html/index.html">(html)</ulink>
-					<ulink url="en/openshift_tools_reference_guide/html_single/index.html">(html single)</ulink>
-					<ulink url="en/openshift_tools_reference_guide/pdf/OpenShift_Tools_Reference_Guide.pdf"
-						>(pdf)</ulink>
-					</primaryie>
-				</indexentry> 
+			</primaryie>
+		</indexentry>
 		
 		<indexentry>
-			<primaryie>Seam Dev Tools Reference Guide <ulink url="en/seam/html/index.html"
+			<primaryie>JSF Tools Tutorial <ulink url="en/jsf_tools_tutorial/html/index.html"
+				>(html)</ulink>
+				<ulink url="en/jsf_tools_tutorial/html_single/index.html">(html single)</ulink>
+				<ulink url="en/jsf_tools_tutorial/pdf/JSF_Tools_Tutorial.pdf">(pdf)</ulink>
+			</primaryie>
+		</indexentry>
+		
+		<indexentry>
+			<primaryie>Maven Reference Guide <ulink
+				url="en/maven_reference/html/index.html">(html)</ulink>
+				<ulink url="en/maven_reference/html_single/index.html">(html single)</ulink>
+				<ulink url="en/maven_reference/pdf/Maven_Tools_Reference_Guide.pdf">(pdf)</ulink>
+			</primaryie>
+		</indexentry>
+		
+		<indexentry>
+			<primaryie>Seam Tools Reference Guide <ulink url="en/seam/html/index.html"
 				>(html)</ulink>
 				<ulink url="en/seam/html_single/index.html">(html single)</ulink>
 				<ulink url="en/seam/pdf/Seam_Reference_Guide.pdf">(pdf)</ulink>
@@ -171,17 +129,17 @@
 				<ulink url="en/ws_restful_reference/html_single/index.html">(html single)</ulink>
 				<ulink url="en/ws_restful_reference/pdf/RESTful_WS_Reference_Guide.pdf"
 					>(pdf)</ulink>
-				</primaryie>
-			</indexentry>
-			
-			<indexentry>
-				<primaryie>WS SOAP Reference Guide <ulink
-					url="en/ws_soap_reference/html/index.html">(html)</ulink>
-					<ulink url="en/ws_soap_reference/html_single/index.html">(html single)</ulink>
-					<ulink url="en/ws_soap_reference/pdf/SOAP_WS_Reference_Guide.pdf"
-						>(pdf)</ulink>
-					</primaryie>
-				</indexentry>
+			</primaryie>
+		</indexentry>
+		
+		<indexentry>
+			<primaryie>WS SOAP Reference Guide <ulink
+				url="en/ws_soap_reference/html/index.html">(html)</ulink>
+				<ulink url="en/ws_soap_reference/html_single/index.html">(html single)</ulink>
+				<ulink url="en/ws_soap_reference/pdf/SOAP_WS_Reference_Guide.pdf"
+					>(pdf)</ulink>
+			</primaryie>
+		</indexentry>
 
     </index>
     
@@ -222,5 +180,5 @@
 			</primaryie>
 		</indexentry> 
 		
-</index>
+	</index>
 </book>

--- a/jboss-tools-docs/pom.xml
+++ b/jboss-tools-docs/pom.xml
@@ -17,56 +17,29 @@
 	<modules>
 
 		<!-- JBT Core Doc -->
-
 		<module>../docs/User_Guide/JBoss_Tools_User_Guide</module>
-		
-		<module>../guides/GettingStartedGuide</module>
-		<module>../guides/Beginners_Guide</module>
 
 		<module>../../jbosstools-birt/docs</module>
-
-		<module>../../jbosstools-central/maven/docs/reference</module>
-
-		<module>../../jbosstools-forge/docs/reference</module>
-
-		<module>../../jbosstools-hibernate/docs/reference</module>
-
 		<module>../../jbosstools-javaee/cdi/docs/reference</module>
+		<module>../../jbosstools-esb/docs/esb_ref_guide</module>
+		<module>../../jbosstools-hibernate/docs/reference</module>
+		<module>../../jbosstools-portlet/docs/reference</module>
+		<module>../../jbosstools-server/jmx/docs/reference</module>
 		<module>../../jbosstools-javaee/jsf/docs/jsf_tools_ref_guide</module>
 		<module>../../jbosstools-javaee/jsf/docs/jsf_tools_tutorial</module>
-		<module>../../jbosstools-javaee/jsf/docs/userguide</module>
+		<module>../../jbosstools-central/maven/docs/reference</module>
 		<module>../../jbosstools-javaee/seam/docs/reference</module>
 		<module>../../jbosstools-javaee/seam/docs/tutorial</module>
-
-
-		<module>../../jbosstools-openshift/docs/reference</module>
-		
-		<module>../../jbosstools-portlet/docs/reference</module>
-
-		<module>../../jbosstools-server/as/docs/reference</module>
-		<module>../../jbosstools-server/jmx/docs/reference</module>
-
+		<module>../../jbosstools-javaee/jsf/docs/userguide</module>
 		<module>../../jbosstools-webservices/docs/restful_reference</module>
 		<module>../../jbosstools-webservices/docs/soap_reference</module>
 
-		<!-- JBT SOA DOC -->
 
+		<!-- JBT SOA DOC -->
 		<module>../../jbosstools-bpel/docs/reference</module>
 
-		<module>../../jbosstools-esb/docs/esb_ref_guide</module>
 
-		<!-- Drools doc have moved to http://docs.jboss.org/drools/release/ -->
-		<!--
-		<module>../../drools/docs/reference</module>
-		<module>../../drools/docs/guvnor_ref</module>
-		-->
-
-		<module>../../jbosstools-jbpm/docs/reference</module>
-		<module>../../jbosstools-jbpm/docs/converter_ref</module>
-
-		<!-- Modeshape doc has moved to https://github.com/ModeShape/modeshape-tools/ -->
-		<module>../../modeshape-tools/docs/ModeShape_Tools_Reference_Guide</module>
-
+		<!-- HTML page listing docs-->
 		<module>index</module>
 	</modules>
 


### PR DESCRIPTION
Involved some reordering in files so that all three follow same pattern
